### PR TITLE
Add gitattributes to disable auto.crlf on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh        text eol=lf


### PR DESCRIPTION
Here is the .gitattributes file. However, I am not quite sure whether this is enought. I think so, since the only problem was the .sh file, but it might be worthwhile to include further points such as PHP.gitattributes. Something like this: https://github.com/gitattributes/gitattributes/blob/master/PHP.gitattributes