### PR TITLE
Allow download bom.json over CDN

### DIFF
--- a/src/app/domain/Artifact.php
+++ b/src/app/domain/Artifact.php
@@ -28,6 +28,7 @@ class Artifact
   private string $permalink;
   private string $downloadUrl;
   private string $folderName;
+  private string $downloadBomUrl;
 
   public function __construct(
     string $fileName,
@@ -39,7 +40,8 @@ class Artifact
     bool $isMavenPluginCompatible,
     string $permalink,
     string $downloadUrl,
-    string $folderName
+    string $folderName,
+    string $downloadBomUrl
   ) {
     $this->fileName = $fileName;
     $this->productName = $productName;
@@ -51,6 +53,7 @@ class Artifact
     $this->permalink = $permalink;
     $this->downloadUrl = $downloadUrl;
     $this->folderName = $folderName;
+    $this->downloadBomUrl = $downloadBomUrl;
   }
 
   public function getVersion(): Version
@@ -61,6 +64,11 @@ class Artifact
   public function getDownloadUrl(): string
   {
     return $this->downloadUrl;
+  }
+
+  public function getDownloadBomUrl(): string
+  {
+    return $this->downloadBomUrl;
   }
 
   public function getInstallationUrl(): string
@@ -98,5 +106,9 @@ class Artifact
   public function getPermalink(): string
   {
     return $this->permalink;
+  }
+
+  public function hasBom(): bool {
+    return !empty($this->downloadBomUrl);
   }
 }

--- a/src/app/domain/ArtifactFactory.php
+++ b/src/app/domain/ArtifactFactory.php
@@ -21,12 +21,7 @@ class ArtifactFactory
 
   private static function fromFilename(string $folderName, string $filename): Artifact
   {
-    return self::createParser($filename)->toArtifact($folderName, $filename);
-  }
-
-  private static function createParser($filename): ArtifactFilenameParser
-  {
-    return new DefaultArtifactFilenameParser();    
+    return ArtifactFilenameParser::toArtifact($folderName, $filename);
   }
 
   private static function createDockerArtifact($versionNumber): Artifact
@@ -61,14 +56,9 @@ class ArtifactFactory
   }
 }
 
-interface ArtifactFilenameParser
+class ArtifactFilenameParser
 {
-  public function toArtifact(string $folderName, string $originalFilename): Artifact;
-}
-
-class DefaultArtifactFilenameParser implements ArtifactFilenameParser
-{
-  public function toArtifact(string $folderName, string $originalFilename): Artifact
+  public static function toArtifact(string $folderName, string $originalFilename): Artifact
   {
     $filename = pathinfo($originalFilename, PATHINFO_FILENAME); // AxonIvyDesigner6.4.0.52683_Windows_x86 or AxonIvyDesigner6.4.0.52683_Osgi_All_x86
     $fileNameArray = explode('_', $filename);

--- a/src/app/pages/download/archive/archive.twig
+++ b/src/app/pages/download/archive/archive.twig
@@ -79,6 +79,10 @@
             <td>
             {% for artifact in releaseInfo.artifacts %}
               <a href="{{ artifact.DownloadUrl }}"><i class="si si-download"> </i></a> &nbsp;<a href="{{ artifact.DownloadUrl }}" title="{{ artifact.FileName }}">{{ artifact.FileName }}</a>
+              {% if artifact.hasBom %}
+                 <a href="{{ artifact.DownloadBomUrl }}" title="Download Software Bill of Materials"><i class="si si-menu"></i></a>
+              {% endif %}
+
               {% if artifact.Type == "Slim All" %}
                 <span class="tooltip">
                   <i class="si si-info"></i>

--- a/test/domain/ReleaseInfoTest.php
+++ b/test/domain/ReleaseInfoTest.php
@@ -5,6 +5,7 @@ namespace test\domain;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use app\domain\ReleaseInfoRepository;
+use app\domain\ReleaseType;
 use app\domain\ReleaseInfo;
 use app\domain\Artifact;
 use app\Config;
@@ -48,6 +49,25 @@ class ReleaseInfoTest extends TestCase
     Assert::assertEquals('/installation?downloadUrl=https://hub.docker.com/r/axonivy/axonivy-engine&version=8.0.1&product=engine&type=docker', $artifact->getInstallationUrl());
     Assert::assertFalse($artifact->isBeta());
     Assert::assertFalse($artifact->isMavenPluginCompatible());
+  }
+
+  public function test_artifactWithBomJson()
+  {
+    $this->testee = ReleaseType::DEV()->releaseInfo();
+    $artifact = $this->testee->getArtifactByProductNameAndType(Artifact::PRODUCT_NAME_DESIGNER, Artifact::TYPE_LINUX);
+    Assert::assertEquals(Artifact::PRODUCT_NAME_DESIGNER, $artifact->getProductName());
+    Assert::assertEquals(Artifact::TYPE_LINUX, $artifact->getType());
+    Assert::assertTrue($artifact->hasBom());
+    Assert::assertEquals('https://download.axonivy.com/dev/AxonIvyDesigner9.1.0.2002051600_Linux_x64.zip.bom.json', $artifact->getDownloadBomUrl());
+  }
+
+  public function test_artifactWithoutBomJson()
+  {
+    $artifact = $this->testee->getArtifactByProductNameAndType(Artifact::PRODUCT_NAME_DESIGNER, Artifact::TYPE_LINUX);
+    Assert::assertEquals(Artifact::PRODUCT_NAME_DESIGNER, $artifact->getProductName());
+    Assert::assertEquals(Artifact::TYPE_LINUX, $artifact->getType());
+    Assert::assertFalse($artifact->hasBom());
+    Assert::assertEquals('', $artifact->getDownloadBomUrl());
   }
 
   public function test_artifactDesignerWindows()


### PR DESCRIPTION
I will upload the json files in the same directory. The json files will have the same name as the file followed by: `.bom.json`.

At the moment they will be only downloadable over the archive, later on I can make this more popular.

![image](https://github.com/user-attachments/assets/c061f4e9-cda1-4af1-bfe4-f16e07ea1429)
