### PR TITLE
Improve version selector dropdown on the archive page

### DIFF
--- a/src/app/pages/download/archive/archive.twig
+++ b/src/app/pages/download/archive/archive.twig
@@ -53,8 +53,14 @@
     <div class="table-wrapper">
       <div class="select-wrapper">
         <select name="version" id="version" onchange="location = this.value;">
-          {% for versionLink in versionLinks %}
-            <a href="#"><option value="{{ versionLink.url }}" {{ (versionLink.id == currentMajorVersion) ? 'selected' : '' }}>{{ versionLink.displayText }}</option></a>
+          {% for categoryName, versions in categorizedVersions %}
+            <optgroup label="{{ categoryName == 'UNSUPPORTED' ? 'Unsupported' : categoryName }}">
+              {% for versionLink in versions %}
+                <option value="{{ versionLink.url }}" {{ (versionLink.id == currentMajorVersion) ? 'selected' : '' }}>
+                  {{ versionLink.id }}
+                </option>
+              {% endfor %}
+            </optgroup>
           {% endfor %}
         </select>
       </div>

--- a/test/pages/download/ArchiveActionTest.php
+++ b/test/pages/download/ArchiveActionTest.php
@@ -44,9 +44,9 @@ class ArchiveActionTest extends TestCase
   public function testDropdown()
   {
     AppTester::assertThatGet('/download/archive/7.x')->ok()
-      ->bodyContains('8.0 (Long Term Support)')
-      ->bodyContains('9 (Leading Edge)')
-      ->bodyContains('6.0 (UNSUPPORTED)')
+      ->bodyContains('8.0')
+      ->bodyContains('9')
+      ->bodyContains('6.0')
       ->bodyContains('unstable')
       ->bodyDoesNotContain('sprint')
       ->bodyDoesNotContain('nightly');


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/ad126443-09db-4b8d-961f-13994ec9f914)


After:
![image](https://github.com/user-attachments/assets/003c2e10-16d2-495d-b6d5-749d5441f1f5)
